### PR TITLE
docker-compose: depend on network-online.target too

### DIFF
--- a/nixos/modules/headless/docker-compose.nix
+++ b/nixos/modules/headless/docker-compose.nix
@@ -17,6 +17,7 @@
         path = [ pkgs.docker-compose ];
         after = [ "docker.service" "docker.socket" "network-online.target" ];
         wantedBy = [ "multi-user.target" ];
+        wants = [ "network-online.target" ];
 
         serviceConfig = {
           Type = "oneshot";


### PR DESCRIPTION
Since 24.05 there are warnings as multi-user.target won't depend on network-online.target in the future.

Closes #133