### PR TITLE
vps: have top level domains and imports inside for caddy

### DIFF
--- a/nixos/hosts/vps/caddy/Caddyfile
+++ b/nixos/hosts/vps/caddy/Caddyfile
@@ -2,8 +2,27 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+#
+# Global configuration
+#
+
 {
     import "/etc/caddy/global/*.Caddyfile"
 }
+
+#
+# Top level domains
+#
+# Note that sub domains require a A or CNAME record in the DNS
+# eg actual IN CNAME ahayzen.com.
+#
+
+home.hayzen.uk {
+    import "/etc/caddy/sites/home-hayzen-uk/*.Caddyfile"
+}
+
+#
+# Other imports
+#
 
 import "/etc/caddy/sites/*.Caddyfile"

--- a/nixos/hosts/vps/homepage/compose.homepage.yml
+++ b/nixos/hosts/vps/homepage/compose.homepage.yml
@@ -8,7 +8,7 @@ services:
       - homepage
     volumes:
       # Caddy configuration file
-      - /etc/caddy/sites/homepage.Caddyfile:/etc/caddy/sites/homepage.Caddyfile:ro
+      - /etc/caddy/sites/home-hayzen-uk/homepage.Caddyfile:/etc/caddy/sites/home-hayzen-uk/homepage.Caddyfile:ro
 
   homepage:
     image: ghcr.io/gethomepage/homepage:v0.9.5@sha256:d24a15d3a1db74151fc57f28d7f65014e5852147c360656a3c15aaf213429ccc

--- a/nixos/hosts/vps/homepage/default.nix
+++ b/nixos/hosts/vps/homepage/default.nix
@@ -16,7 +16,7 @@
     };
 
     environment.etc = {
-      "caddy/sites/homepage.Caddyfile".source = ./homepage.Caddyfile;
+      "caddy/sites/home-hayzen-uk/homepage.Caddyfile".source = ./homepage.Caddyfile;
       "homepage/bookmarks.yaml".source = ./bookmarks.yaml;
       "homepage/services.yaml".source = ./services.yaml;
       "homepage/settings.yaml".source = ./settings.yaml;
@@ -28,7 +28,7 @@
     # Note agenix files are not possible and will need the version bumping
     # which causes the hash of the docker-compose file to change.
     systemd.services."docker-compose-runner".reloadTriggers = [
-      (builtins.hashFile "sha256" config.environment.etc."caddy/sites/homepage.Caddyfile".source)
+      (builtins.hashFile "sha256" config.environment.etc."caddy/sites/home-hayzen-uk/homepage.Caddyfile".source)
       (builtins.hashFile "sha256" config.environment.etc."homepage/bookmarks.yaml".source)
       (builtins.hashFile "sha256" config.environment.etc."homepage/services.yaml".source)
       (builtins.hashFile "sha256" config.environment.etc."homepage/settings.yaml".source)

--- a/nixos/hosts/vps/rathole/compose.rathole.yml
+++ b/nixos/hosts/vps/rathole/compose.rathole.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       # Caddy configuration file
       - /etc/caddy/sites/rathole.Caddyfile:/etc/caddy/sites/rathole.Caddyfile:ro
+      - /etc/caddy/sites/home-hayzen-uk/rathole.sftpgo.Caddyfile:/etc/caddy/sites/home-hayzen-uk/rathole.sftpgo.Caddyfile:ro
 
   rathole:
     image: docker.io/rapiz1/rathole:v0.5.0@sha256:a31b9178e985d4a84f46d4c3af6aa200ee0c5e7f821c7075a1f6669fb77392b1

--- a/nixos/hosts/vps/rathole/default.nix
+++ b/nixos/hosts/vps/rathole/default.nix
@@ -26,6 +26,7 @@
 
     environment.etc = {
       "caddy/sites/rathole.Caddyfile".source = ./rathole.Caddyfile;
+      "caddy/sites/home-hayzen-uk/rathole.sftpgo.Caddyfile".source = ./rathole.sftpgo.Caddyfile;
       "rathole/config.1.toml".
       source =
         if config.ahayzen.testing
@@ -39,6 +40,7 @@
     # which causes the hash of the docker-compose file to change.
     systemd.services."docker-compose-runner".reloadTriggers = [
       (builtins.hashFile "sha256" config.environment.etc."caddy/sites/rathole.Caddyfile".source)
+      (builtins.hashFile "sha256" config.environment.etc."caddy/sites/home-hayzen-uk/rathole.sftpgo.Caddyfile".source)
     ];
   };
 }

--- a/nixos/hosts/vps/rathole/rathole.Caddyfile
+++ b/nixos/hosts/vps/rathole/rathole.Caddyfile
@@ -8,13 +8,6 @@
 # eg actual IN CNAME ahayzen.com.
 #
 
-home.hayzen.uk {
-    # SFTPGo proxy
-    handle_path /sftpgo/* {
-        reverse_proxy rathole:8880
-    }
-}
-
 # Actual proxy
 actual.ahayzen.com {
     reverse_proxy rathole:8506

--- a/nixos/hosts/vps/rathole/rathole.sftpgo.Caddyfile
+++ b/nixos/hosts/vps/rathole/rathole.sftpgo.Caddyfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-# Home page
-handle {
-    reverse_proxy homepage:3000
+# SFTPGo proxy
+handle_path /sftpgo/* {
+    reverse_proxy rathole:8880
 }


### PR DESCRIPTION
This avoids having to declare the domain twice which causes errors.