### PR TITLE
lab: ensure firewall ports are open for jellyfin on lab

### DIFF
--- a/nixos/hosts/lab/jellyfin/default.nix
+++ b/nixos/hosts/lab/jellyfin/default.nix
@@ -13,5 +13,11 @@
     ahayzen = {
       docker-compose-files = [ ./compose.jellyfin.yml ];
     };
+
+    # Ensure Jellyfin port and autodiscovery port is open
+    networking.firewall.allowedTCPPorts = [
+      7359
+      8096
+    ];
   };
 }


### PR DESCRIPTION
Related to #4