### PR TITLE
lab: change bindfs to be a network mount not local-fs

### DIFF
--- a/nixos/hosts/lab/bindfs.nix
+++ b/nixos/hosts/lab/bindfs.nix
@@ -12,7 +12,9 @@
     mounts = [{
       type = "fuse.bindfs";
       mountConfig = {
-        Options = "map=unpriv/unpriv-user1000:@unpriv/@unpriv-user1000";
+        # Use _netdev so that systemd thinks this is a network filesystem
+        # not a local filesystem (as we need sshfs first) to improve ordering
+        Options = "map=unpriv/unpriv-user1000:@unpriv/@unpriv-user1000,_netdev";
       };
       # As sshfs provides a mount this causes us to depend on it
       what = "/mnt/data";


### PR DESCRIPTION
This should improve the ordering of the mounts and hopefully avoid an ordering cycle.

Related to #365