### PR TITLE
systemd: improve reload vs restart triggers

### DIFF
--- a/nixos/hosts/lab/immich/compose.immich.yml
+++ b/nixos/hosts/lab/immich/compose.immich.yml
@@ -25,7 +25,7 @@ services:
       - /var/cache/docker-compose-runner/immich/server/encoded-video:/usr/src/app/upload/encoded-video
     env_file:
       - /etc/immich/settings.env
-      - /etc/immich/settings_secrets.1.env
+      - /etc/immich/settings_secrets.env
     expose:
       - 3001
     depends_on:
@@ -40,7 +40,7 @@ services:
       - /var/cache/docker-compose-runner/immich/machine-learning-cache:/cache
     env_file:
       - /etc/immich/settings.env
-      - /etc/immich/settings_secrets.1.env
+      - /etc/immich/settings_secrets.env
     restart: always
 
   immich-redis:
@@ -57,7 +57,7 @@ services:
       POSTGRES_INITDB_ARGS: '--data-checksums'
     env_file:
       - /etc/immich/settings.env
-      - /etc/immich/settings_secrets.1.env
+      - /etc/immich/settings_secrets.env
     volumes:
       - /var/cache/docker-compose-runner/immich/postgres:/var/lib/postgresql/data
       - /var/lib/docker-compose-runner/immich/postgres:/var/lib/docker-compose-runner/immich/postgres

--- a/nixos/hosts/lab/immich/default.nix
+++ b/nixos/hosts/lab/immich/default.nix
@@ -34,19 +34,21 @@
 
     environment.etc = {
       "immich/settings.env".source = ./immich.env;
-      "immich/settings_secrets.1.env".
+      "immich/settings_secrets.env".
       source =
         if config.ahayzen.testing
         then ./immich-secrets.vm.env
         else config.age.secrets.immich_env.path;
     };
 
-    # Reload if static files change
+    # Restart if static files change
     #
     # Note agenix files are not possible and will need the version bumping
     # which causes the hash of the docker-compose file to change.
-    systemd.services."docker-compose-runner".reloadTriggers = [
+    systemd.services."docker-compose-runner".restartTriggers = [
       (builtins.hashFile "sha256" config.environment.etc."immich/settings.env".source)
+      # Agenix path with a version that can be bumped
+      "/etc/immich/settings_secrets.env-1"
     ];
   };
 }

--- a/nixos/hosts/vps/caddy/default.nix
+++ b/nixos/hosts/vps/caddy/default.nix
@@ -16,11 +16,11 @@
     };
   };
 
-  # Reload if static files change
+  # Restart if static files change
   #
   # Note agenix files are not possible and will need the version bumping
   # which causes the hash of the docker-compose file to change.
-  systemd.services."docker-compose-runner".reloadTriggers = [
+  systemd.services."docker-compose-runner".restartTriggers = [
     (builtins.hashFile "sha256" config.environment.etc."caddy/Caddyfile".source)
   ];
 }

--- a/nixos/hosts/vps/hayzen-uk/default.nix
+++ b/nixos/hosts/vps/hayzen-uk/default.nix
@@ -11,11 +11,11 @@
     "hayzen-uk/index.html".source = ./index.html;
   };
 
-  # Reload if static files change
+  # Restart if static files change
   #
   # Note agenix files are not possible and will need the version bumping
   # which causes the hash of the docker-compose file to change.
-  systemd.services."docker-compose-runner".reloadTriggers = [
+  systemd.services."docker-compose-runner".restartTriggers = [
     (builtins.hashFile "sha256" config.environment.etc."caddy/sites/hayzen-uk.Caddyfile".source)
     (builtins.hashFile "sha256" config.environment.etc."hayzen-uk/index.html".source)
   ];

--- a/nixos/hosts/vps/homepage/default.nix
+++ b/nixos/hosts/vps/homepage/default.nix
@@ -23,11 +23,11 @@
       "homepage/widgets.yaml".source = ./widgets.yaml;
     };
 
-    # Reload if static files change
+    # Restart if static files change
     #
     # Note agenix files are not possible and will need the version bumping
     # which causes the hash of the docker-compose file to change.
-    systemd.services."docker-compose-runner".reloadTriggers = [
+    systemd.services."docker-compose-runner".restartTriggers = [
       (builtins.hashFile "sha256" config.environment.etc."caddy/sites/home-hayzen-uk.Caddyfile".source)
       (builtins.hashFile "sha256" config.environment.etc."homepage/bookmarks.yaml".source)
       (builtins.hashFile "sha256" config.environment.etc."homepage/services.yaml".source)

--- a/nixos/hosts/vps/rathole/compose.rathole.yml
+++ b/nixos/hosts/vps/rathole/compose.rathole.yml
@@ -9,7 +9,6 @@ services:
     volumes:
       # Caddy configuration file
       - /etc/caddy/sites/rathole.Caddyfile:/etc/caddy/sites/rathole.Caddyfile:ro
-      - /etc/caddy/sites/home-hayzen-uk/rathole.sftpgo.Caddyfile:/etc/caddy/sites/home-hayzen-uk/rathole.sftpgo.Caddyfile:ro
 
   rathole:
     image: docker.io/rapiz1/rathole:v0.5.0@sha256:a31b9178e985d4a84f46d4c3af6aa200ee0c5e7f821c7075a1f6669fb77392b1
@@ -33,4 +32,4 @@ services:
       # Expose OpenVPN
       - "9194:9194"
     volumes:
-      - /etc/rathole/config.1.toml:/etc/rathole/config.toml:ro
+      - /etc/rathole/config.toml:/etc/rathole/config.toml:ro

--- a/nixos/hosts/vps/rathole/default.nix
+++ b/nixos/hosts/vps/rathole/default.nix
@@ -26,19 +26,21 @@
 
     environment.etc = {
       "caddy/sites/rathole.Caddyfile".source = ./rathole.Caddyfile;
-      "rathole/config.1.toml".
+      "rathole/config.toml".
       source =
         if config.ahayzen.testing
         then ./rathole.vm.toml
         else config.age.secrets.rathole_toml.path;
     };
 
-    # Reload if static files change
+    # Restart if static files change
     #
     # Note agenix files are not possible and will need the version bumping
     # which causes the hash of the docker-compose file to change.
-    systemd.services."docker-compose-runner".reloadTriggers = [
+    systemd.services."docker-compose-runner".restartTriggers = [
       (builtins.hashFile "sha256" config.environment.etc."caddy/sites/rathole.Caddyfile".source)
+      # Agenix path with a version that can be bumped
+      "/etc/rathole/config.toml-1"
     ];
   };
 }

--- a/nixos/hosts/vps/wagtail-ahayzen/compose.wagtail-ahayzen.yml
+++ b/nixos/hosts/vps/wagtail-ahayzen/compose.wagtail-ahayzen.yml
@@ -28,6 +28,6 @@ services:
       # Wagtail static data
       - /var/lib/docker-compose-runner/wagtail-ahayzen/static:/srv/webapp/static
       # Wagtail local settings file
-      - /etc/ahayzen.com/local.1.py:/srv/webapp/ahayzen.com/ahayzen/settings/local.py:ro
+      - /etc/ahayzen.com/local.py:/srv/webapp/ahayzen.com/ahayzen/settings/local.py:ro
       # Wagtail docs folder
       - /var/lib/docker-compose-runner/wagtail-ahayzen/docs:/srv/webapp/docs

--- a/nixos/hosts/vps/wagtail-ahayzen/default.nix
+++ b/nixos/hosts/vps/wagtail-ahayzen/default.nix
@@ -31,19 +31,21 @@
 
     environment.etc = {
       "caddy/sites/ahayzen.Caddyfile".source = ./ahayzen.Caddyfile;
-      "ahayzen.com/local.1.py".
+      "ahayzen.com/local.py".
       source =
         if config.ahayzen.testing
         then ./local.vm.py
         else config.age.secrets.local-py_ahayzen-com.path;
     };
 
-    # Reload if static files change
+    # Restart if static files change
     #
     # Note agenix files are not possible and will need the version bumping
     # which causes the hash of the docker-compose file to change.
-    systemd.services."docker-compose-runner".reloadTriggers = [
+    systemd.services."docker-compose-runner".restartTriggers = [
       (builtins.hashFile "sha256" config.environment.etc."caddy/sites/ahayzen.Caddyfile".source)
+      # Agenix path with a version that can be bumped
+      "/etc/ahayzen/local.py-1"
     ];
   };
 }

--- a/nixos/hosts/vps/wagtail-yumekasaito/compose.wagtail-yumekasaito.yml
+++ b/nixos/hosts/vps/wagtail-yumekasaito/compose.wagtail-yumekasaito.yml
@@ -28,4 +28,4 @@ services:
       # Wagtail static data
       - /var/lib/docker-compose-runner/wagtail-yumekasaito/static:/srv/webapp/static
       # Wagtail local settings file
-      - /etc/yumekasaito.com/local.1.py:/srv/webapp/yumekasaito.com/yumekasaito/settings/local.py:ro
+      - /etc/yumekasaito.com/local.py:/srv/webapp/yumekasaito.com/yumekasaito/settings/local.py:ro

--- a/nixos/hosts/vps/wagtail-yumekasaito/default.nix
+++ b/nixos/hosts/vps/wagtail-yumekasaito/default.nix
@@ -31,19 +31,21 @@
 
     environment.etc = {
       "caddy/sites/yumekasaito.Caddyfile".source = ./yumekasaito.Caddyfile;
-      "yumekasaito.com/local.1.py".
+      "yumekasaito.com/local.py".
       source =
         if config.ahayzen.testing
         then ./local.vm.py
         else config.age.secrets.local-py_yumekasaito-com.path;
     };
 
-    # Reload if static files change
+    # Restart if static files change
     #
     # Note agenix files are not possible and will need the version bumping
     # which causes the hash of the docker-compose file to change.
-    systemd.services."docker-compose-runner".reloadTriggers = [
+    systemd.services."docker-compose-runner".restartTriggers = [
       (builtins.hashFile "sha256" config.environment.etc."caddy/sites/yumekasaito.Caddyfile".source)
+      # Agenix path with a version that can be bumped
+      "/etc/yumekasaito.com/local.py-1"
     ];
   };
 }


### PR DESCRIPTION
A docker compose pull does not trigger a restart of the service if only the contents of the volume have changed and not the yml.

Closes #308