### PR TITLE
nix: we are using flakes so do not need nix channels configured

### DIFF
--- a/nixos/modules/all/nix.nix
+++ b/nixos/modules/all/nix.nix
@@ -13,6 +13,11 @@
   hardware.enableRedistributableFirmware = true;
 
   nix = {
+    # Disable channels as we are using flakes
+    #
+    # https://github.com/NixOS/nix/issues/2982#issuecomment-2477618346
+    channel.enable = false;
+
     # Enable garbage collection
     gc = {
       # Enable when not in testing mode


### PR DESCRIPTION
This removes errors using nix-shell