### PR TITLE
desktop: pulseaudio is now false by default do not set

### DIFF
--- a/nixos/modules/desktop/pipewire.nix
+++ b/nixos/modules/desktop/pipewire.nix
@@ -4,7 +4,6 @@
 
 { lib, ... }: {
   # Enable sound with pipewire.
-  hardware.pulseaudio.enable = lib.mkForce false;
   security.rtkit.enable = true;
   services.pipewire = {
     enable = true;


### PR DESCRIPTION
And this fails with upcoming 25.05 anyway.