### PR TITLE
tests: shorten audiobookshelf name

### DIFF
--- a/tests/lab-audiobookshelf.nix
+++ b/tests/lab-audiobookshelf.nix
@@ -18,7 +18,7 @@
 # - backup script
 
 (import ./lib.nix) {
-  name = "lab-audiobookshelf-test";
+  name = "lab-abs-test";
   nodes = {
     vps = { self, pkgs, ... }: {
       imports =


### PR DESCRIPTION
vm-test-run-lab-audiobookshelf-test> Traceback (most recent call last):
vm-test-run-lab-audiobookshelf-test>   File "/nix/store/gl1zp3cz9rspwh0hh7v6lha1jhrvymka-nixos-test-driver-1.1/bin/.nixos-test-driver-wrapped", line 9, in <module>
vm-test-run-lab-audiobookshelf-test>     sys.exit(main())
vm-test-run-lab-audiobookshelf-test>              ^^^^^^
vm-test-run-lab-audiobookshelf-test>   File "/nix/store/gl1zp3cz9rspwh0hh7v6lha1jhrvymka-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/__init__.py", line 152, in main
vm-test-run-lab-audiobookshelf-test>     driver.run_tests()
vm-test-run-lab-audiobookshelf-test>   File "/nix/store/gl1zp3cz9rspwh0hh7v6lha1jhrvymka-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/driver.py", line 235, in run_tests
vm-test-run-lab-audiobookshelf-test>     self.test_script()
vm-test-run-lab-audiobookshelf-test>   File "/nix/store/gl1zp3cz9rspwh0hh7v6lha1jhrvymka-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/driver.py", line 199, in test_script
vm-test-run-lab-audiobookshelf-test>     exec(self.tests, symbols, None)
vm-test-run-lab-audiobookshelf-test>   File "<string>", line 3, in <module>
vm-test-run-lab-audiobookshelf-test>   File "/nix/store/gl1zp3cz9rspwh0hh7v6lha1jhrvymka-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/driver.py", line 245, in start_all
vm-test-run-lab-audiobookshelf-test>     machine.start()
vm-test-run-lab-audiobookshelf-test>   File "/nix/store/gl1zp3cz9rspwh0hh7v6lha1jhrvymka-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/machine.py", line 1140, in start
vm-test-run-lab-audiobookshelf-test>     monitor_socket = create_socket(clear(self.monitor_path))
vm-test-run-lab-audiobookshelf-test>                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vm-test-run-lab-audiobookshelf-test>   File "/nix/store/gl1zp3cz9rspwh0hh7v6lha1jhrvymka-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/machine.py", line 1136, in create_socket
vm-test-run-lab-audiobookshelf-test>     s.bind(str(path))
vm-test-run-lab-audiobookshelf-test> OSError: AF_UNIX path too long