### PR TITLE
wg-quick: use a /25 subnet in the high numbers

### DIFF
--- a/nixos/hosts/lab-jonsbo-n3/wg-quick/default.nix
+++ b/nixos/hosts/lab-jonsbo-n3/wg-quick/default.nix
@@ -28,7 +28,7 @@
 
     networking.wg-quick.interfaces = {
       wg0 = {
-        address = [ "172.28.228.2/24" ];
+        address = [ "172.28.228.130/32" ];
         dns = [ "9.9.9.9" ];
         listenPort = 51820;
         mtu = 1420;
@@ -38,7 +38,7 @@
           {
             # VPS public key
             publicKey = if config.ahayzen.testing then "etSgGU6oJzeVY9hTESENy09pC2UVBMKAlqRpyGwC0wY=" else "x/OmP3Aa3i7XhsuoZT6svz56eLdv0E8oUtYV4jqkmTs=";
-            allowedIPs = [ "172.28.228.0/24" ];
+            allowedIPs = [ "172.28.228.128/25" ];
             endpoint = "ahayzen.com:51820";
             persistentKeepalive = 25;
             presharedKeyFile = if config.ahayzen.testing then "${./wg-pre-shared-test}" else config.age.secrets.wg-pre-shared.path;

--- a/nixos/hosts/vps/rathole/compose.rathole.yml
+++ b/nixos/hosts/vps/rathole/compose.rathole.yml
@@ -50,7 +50,7 @@ services:
   socat-https:
     image: docker.io/alpine/socat:1.8.1.3@sha256:188fe0a22182f81c16def9d1137930121eaa3023f427164e32c0d2f118f79dd6
     restart: unless-stopped
-    command: "TCP4-LISTEN:9443,fork,reuseaddr TCP4:172.28.228.2:443"
+    command: "TCP4-LISTEN:9443,fork,reuseaddr TCP4:172.28.228.130:443"
     expose:
       - 9443
     # NOTE: this is not network=host so that caddy container can reach it

--- a/nixos/hosts/vps/wg-quick/default.nix
+++ b/nixos/hosts/vps/wg-quick/default.nix
@@ -35,7 +35,7 @@
 
       wg-quick.interfaces = {
         wg0 = {
-          address = [ "172.28.228.1/24" ];
+          address = [ "172.28.228.129/32" ];
           dns = [ "9.9.9.9" ];
           listenPort = 51820;
           mtu = 1420;
@@ -45,7 +45,7 @@
             {
               # Lab public key
               publicKey = if config.ahayzen.testing then "iSJhX9/U0wZ/VyztUBnkEmFw9TVVPNtQwlmTCUaB2QY=" else "f/hmn0DmhLT0JoVrA8HtBEE3KbKvJgrT9u2UZk/Qc1w=";
-              allowedIPs = [ "172.28.228.0/24" ];
+              allowedIPs = [ "172.28.228.128/25" ];
               persistentKeepalive = 25;
               presharedKeyFile = if config.ahayzen.testing then "${./wg-pre-shared-test}" else config.age.secrets.wg-pre-shared.path;
             }


### PR DESCRIPTION
This reduces the chance of a collision further.