### PR TITLE
wg-quick: use different port for our bridge connection

### DIFF
--- a/nixos/hosts/lab-jonsbo-n3/wg-quick/default.nix
+++ b/nixos/hosts/lab-jonsbo-n3/wg-quick/default.nix
@@ -38,7 +38,7 @@
             # VPS public key
             publicKey = if config.ahayzen.testing then "etSgGU6oJzeVY9hTESENy09pC2UVBMKAlqRpyGwC0wY=" else "x/OmP3Aa3i7XhsuoZT6svz56eLdv0E8oUtYV4jqkmTs=";
             allowedIPs = [ "172.28.228.128/25" ];
-            endpoint = "ahayzen.com:51820";
+            endpoint = "ahayzen.com:51821";
             persistentKeepalive = 25;
             presharedKeyFile = if config.ahayzen.testing then "${./wg-pre-shared-test}" else config.age.secrets.wg-pre-shared.path;
           }

--- a/nixos/hosts/vps/wg-quick/default.nix
+++ b/nixos/hosts/vps/wg-quick/default.nix
@@ -43,7 +43,7 @@
         wg0 = {
           address = [ "172.28.228.129/32" ];
           dns = [ "9.9.9.9" "149.112.112.112" ];
-          listenPort = 51820;
+          listenPort = 51821;
           mtu = 1420;
           # VPS private key
           privateKeyFile = if config.ahayzen.testing then "${./wg-vps-test-private}" else config.age.secrets.wg-vps-private.path;
@@ -62,7 +62,7 @@
 
     networking.firewall =
       {
-        allowedUDPPorts = [ 51820 ];
+        allowedUDPPorts = [ 51821 ];
       };
 
     # Restart if static files change


### PR DESCRIPTION
As wg-easy may use the default port.