### PR TITLE
wg-easy: initial password must be at least 12 characters

### DIFF
--- a/docs/software/services/wireguard.md
+++ b/docs/software/services/wireguard.md
@@ -31,8 +31,13 @@ This means that the first wireguard layer should use a MTU of 1420, the second 1
 
 ## `wg-easy`
 
-Change the password after initial login.
+Change the password after initial login, this can be done via the CLI with similar to the following
+```console
+docker compose exec -it wg-easy cli db:admin:reset
+```
+https://wg-easy.github.io/wg-easy/v15.3/guides/cli/#reset-password
 
 In the admin panel interface section, set MTU to the rules above and persistent keepalive to 25s.
 
-Update the hooks to use nftables as wg-easy still uses iptables, as seen in the podman documentation https://wg-easy.github.io/wg-easy/v15.3/examples/tutorials/podman-nft/#edit-hooks
+Update the hooks to use nftables as wg-easy still uses iptables, as seen in the podman documentation
+https://wg-easy.github.io/wg-easy/v15.3/examples/tutorials/podman-nft/#edit-hooks

--- a/nixos/hosts/lab-jonsbo-n3/wg-easy/compose.wg-easy.yml
+++ b/nixos/hosts/lab-jonsbo-n3/wg-easy/compose.wg-easy.yml
@@ -16,7 +16,7 @@ services:
       - INIT_ENABLED=true
       # Init group 1
       - INIT_USERNAME=admin
-      - INIT_PASSWORD=changeme
+      - INIT_PASSWORD=changeme1234
       - INIT_HOST=wg-easy.hayzen.uk
       - INIT_PORT=51820
       # Init group 2


### PR DESCRIPTION
Workaround as cannot change the password on the CLI until the next release
https://github.com/wg-easy/wg-easy/issues/2682