### PR TITLE
docs: add ffmpeg note to fix aspect ratio

### DIFF
--- a/docs/software/tools/ffmpeg.md
+++ b/docs/software/tools/ffmpeg.md
@@ -1,0 +1,14 @@
+<!--
+SPDX-FileCopyrightText: Andrew Hayzen <ahayzen@gmail.com>
+
+SPDX-License-Identifier: MPL-2.0
+-->
+
+# ffmpeg
+
+## Fix incorrect aspect ratio
+
+```console
+nix-shell -p ffmpeg
+ffmpeg -i input.mkv -map 0 -c copy -aspect 16:9 output.mkv 
+```


### PR DESCRIPTION
If the source video was wrong when using MakeMKV this can be fixed using ffmpeg.